### PR TITLE
Replace Vite placeholder text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,28 @@
-# React + Vite
+# Tool Schema Builder
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Tool Schema Builder is a web-based editor for creating, editing and exporting function-calling tool schemas for your models.
 
-Currently, two official plugins are available:
+## Getting Started
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+Install dependencies and start the development server:
 
-## Expanding the ESLint configuration
+```bash
+npm install
+npm run dev
+```
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+## Building for Production
+
+Run the following command to generate a production build:
+
+```bash
+npm run build
+```
+
+## Preview
+
+After building, preview the production build locally with:
+
+```bash
+npm run preview
+```

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script src="https://cdn.tailwindcss.com"></script>
-    <title>Vite + React</title>
+    <title>Tool Schema Builder</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- update site title to "Tool Schema Builder"
- replace README template with info about Tool Schema Builder

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_68711ae323348326a6890bb626b2abe4